### PR TITLE
Fix repo folder mismatch - restore script tracking

### DIFF
--- a/Descent/Assets/Scripts/GameManager.cs
+++ b/Descent/Assets/Scripts/GameManager.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        Debug.Log("Game Manager Initialized");
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Descent/Assets/Scripts/GameManager.cs.meta
+++ b/Descent/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5c8a2ec78b04994b8d8ecc746f2a28d

--- a/Descent/Assets/Scripts/OptionsMenu.cs
+++ b/Descent/Assets/Scripts/OptionsMenu.cs
@@ -11,7 +11,6 @@ public class OptionsMenu : MonoBehaviour
     public Slider volumeSlider;
     public TMP_Dropdown resolutionDropdown;
     public Toggle fullscreenToggle;
-    public AudioSource uiAudioSource;
 
     private Resolution[] resolutions;
 
@@ -50,15 +49,11 @@ public class OptionsMenu : MonoBehaviour
 
         // Fullscreen toggle
         fullscreenToggle.isOn = Screen.fullScreen;
-        fullscreenToggle.onValueChanged.AddListener(SetFullscreen);
 
         // Initialize volume slider
         if (volumeSlider != null)
         {
-            // Load saved value, default to 1
-            float savedVolume = PlayerPrefs.GetFloat("MasterVolume", 1f);
-            volumeSlider.value = savedVolume;
-            SetVolume(); // Apply immediately
+            SetVolume();
         }
 
         // Add listeners to UI elements
@@ -70,13 +65,8 @@ public class OptionsMenu : MonoBehaviour
     public void SetVolume()
     {
         if (volumeSlider == null || audioMixer == null) return;
-
         float volume = Mathf.Clamp(volumeSlider.value, 0.0001f, 1f);
         audioMixer.SetFloat("MasterVolume", Mathf.Log10(volume) * 20);
-
-        // Save volume to PlayerPrefs so other scenes can access it
-        PlayerPrefs.SetFloat("MasterVolume", volume);
-        PlayerPrefs.Save();
     }
 
     public void SetResolution(int index)
@@ -101,20 +91,11 @@ public class OptionsMenu : MonoBehaviour
 
     public void SetFullscreen(bool isFullscreen)
     {
-        // Apply fullscreen
-        Screen.fullScreenMode = isFullscreen 
-            ? FullScreenMode.FullScreenWindow 
-            : FullScreenMode.Windowed;
-
-        // Play the switch sound
-        if (uiAudioSource != null)
-        {
-            uiAudioSource.Play(); // Plays the AudioSource.clip assigned in Inspector
-        }
+        Screen.fullScreen = isFullscreen;
     }
 
     public void BackToMenu()
     {
-        SceneManager.LoadScene("TitleMenuScene");
+        SceneManager.LoadScene("MainMenu");
     }
 }

--- a/Descent/Assets/Scripts/SettingsData.cs
+++ b/Descent/Assets/Scripts/SettingsData.cs
@@ -1,0 +1,10 @@
+[System.Serializable]
+public class SettingsData
+{
+    public float masterVolume = 1f;
+    public float musicVolume = 1f;
+    public float sfxVolume = 1f;
+
+    public int resolutionIndex = 0;
+    public bool fullscreen = true;
+}

--- a/Descent/Assets/Scripts/SettingsData.cs.meta
+++ b/Descent/Assets/Scripts/SettingsData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6afb20e64dccd6d4a83042682aae306f

--- a/Descent/Assets/Scripts/SettingsManager.cs
+++ b/Descent/Assets/Scripts/SettingsManager.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+
+public class SettingsManager : MonoBehaviour
+{
+    public static SettingsManager Instance;
+    public SettingsData currentSettings;
+    string savePath;
+
+
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            savePath = Application.persistentDataPath + "/settings.json";
+            LoadSettings();
+
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    void Start()
+    {
+        Debug.Log("Settings Manager Initialized");
+    }
+
+    public void SaveSettings()
+    {
+        string json = JsonUtility.ToJson(currentSettings, true);
+        System.IO.File.WriteAllText(savePath, json);
+        Debug.Log("Settings saved to: " + savePath);
+    }
+
+    public void LoadSettings()
+    {
+        if (System.IO.File.Exists(savePath))
+        {
+            string json = System.IO.File.ReadAllText(savePath);
+            currentSettings = JsonUtility.FromJson<SettingsData>(json);
+            Debug.Log("Settings loaded.");
+        }
+        else
+        {
+            currentSettings = new SettingsData();
+            SaveSettings();
+            Debug.Log("Created default settings.");
+        }
+    }
+}
+

--- a/Descent/Assets/Scripts/SettingsManager.cs.meta
+++ b/Descent/Assets/Scripts/SettingsManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0e11f61f928bb14ba2426cba1132e29


### PR DESCRIPTION
1. Resolved a local repo folder mismatch that caused Unity/VS edits not to be tracked by GitHub Desktop.
2. Copied/replaced the Scripts files into the correct tracked project folder so changes are now captured.

**Files:**
Updated Scripts (.cs) and related .meta files under Descent/Assets/Scripts.

**Notes:**
GitHub Desktop previously showed “No local changes” due to the mismatch; after fix, changes are now visible.